### PR TITLE
Add Dependacy Map

### DIFF
--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -140,43 +140,43 @@
 	</ul>
 	<!-- <p>Looking for Subresource Integrity (SRI) values for jQuery files? They can be found on the <a href="./sri-en.html">SRI for CDTS page</a>.</p> -->
 	<p>Are you using an older version of the CDTS? Older versions will still work but they will not receive any updates to the Canada.ca theme or any fixes related to the WET.</p>
-	<h3>Supported Depenancies</h3>
+	<h3>Supported Dependencies</h3>
 	<table class="table table-bordered">
-		<caption class="wb-inv">Supported Depenancies Version Map</caption>
+		<caption class="wb-inv">Supported Dependencies Version Map</caption>
 		<thead>
 			<tr>
-				<th scope="col">WET</th>
-				<th scope="col">GC Web</th>
-				<th scope="col">GC Intranet</th>
+				<th scope="col"><a href="https://github.com/wet-boew/wet-boew">WET-BOEW</a></th>
+				<th scope="col"><a href="https://github.com/wet-boew/GCWeb">GC Web</a></th>
+				<th scope="col"><a href="https://github.com/wet-boew/theme-gc-intranet">GC Intranet</a></th>
 				<th scope="col" class="active">CDTS</th>
-				<th scope="col">DotNetTemplates</th>
-				<th scope="col">JavaTemplates</th>
+				<th scope="col"><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates">DotNetTemplates</a></th>
+				<th scope="col"><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/JavaTemplates">JavaTemplates</a></th>
 			</tr>
 		</thead>
 		<tbody>
 			<tr>
-				<td>v4.0.32</td>
-				<td>v6.0</td>
-				<td>v4.0.27</td>
+				<td><a href="https://github.com/wet-boew/wet-boew/releases/tag/v4.0.32">v4.0.32</a></td>
+				<td><a href="https://github.com/wet-boew/GCWeb/releases/tag/v6.0">v6.0</a></td>
+				<td><a href="https://github.com/wet-boew/theme-gc-intranet/releases/tag/v4.0.27">v4.0.27</a></td>
 				<td class="active">v4.0.32</td>
-				<td>v1.32.0 & v2.0.0-v2.0.1</td>
+				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#1.32.0">v1.32.0</a> & <a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#v2.0.0">v2.0.0</a>-<a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#v2.0.1">v2.0.1</a></td>
 				<td>tbd</td>
 			</tr>
 			<tr>
-				<td>v4.0.31</td>
-				<td>v5.1</td>
-				<td>v4.0.26</td>
+				<td><a href="https://github.com/wet-boew/wet-boew/releases/tag/v4.0.31">v4.0.31</a></td>
+				<td><a href="https://github.com/wet-boew/GCWeb/releases/tag/v5.1">v5.1</a></td>
+				<td><a href="https://github.com/wet-boew/theme-gc-intranet/releases/tag/v4.0.26">v4.0.26</a></td>
 				<td class="active">v4.0.31</td>
-				<td>v1.31.0</td>
-				<td>v1.31.0</td>
+				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#1.31.0">v1.31.0</a></td>
+				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/JavaTemplates/-/releases#1.31.0">v1.31.0</a></td>
 			</tr>			
 			<tr>
-				<td>v4.0.30</td>
-				<td>v5.0</td>
-				<td>v4.0.24</td>
+				<td><a href="https://github.com/wet-boew/wet-boew/releases/tag/v4.0.30">v4.0.30</a></td>
+				<td><a href="https://github.com/wet-boew/GCWeb/releases/tag/v5.0">v5.0</a></td>
+				<td><a href="https://github.com/wet-boew/theme-gc-intranet/releases/tag/v4.0.24">v4.0.24</a></td>
 				<td class="active">v4.0.30</td>
-				<td>v1.30.0</td>
-				<td>v1.30.0</td>
+				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#1.30.0">v1.30.0</a></td>
+				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/JavaTemplates/-/releases#1.30.0">v1.30.0</a></td>
 			</tr>
 		</tbody>
 	</table>

--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -140,6 +140,46 @@
 	</ul>
 	<!-- <p>Looking for Subresource Integrity (SRI) values for jQuery files? They can be found on the <a href="./sri-en.html">SRI for CDTS page</a>.</p> -->
 	<p>Are you using an older version of the CDTS? Older versions will still work but they will not receive any updates to the Canada.ca theme or any fixes related to the WET.</p>
+	<h3>Supported Depenancies</h3>
+	<table class="table table-bordered">
+		<caption class="wb-inv">Supported Depenancies Version Map</caption>
+		<thead>
+			<tr>
+				<th scope="col">WET</th>
+				<th scope="col">GC Web</th>
+				<th scope="col">GC Intranet</th>
+				<th scope="col" class="active">CDTS</th>
+				<th scope="col">DotNetTemplates</th>
+				<th scope="col">JavaTemplates</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>v4.0.32</td>
+				<td>v6.0</td>
+				<td>v4.0.27</td>
+				<td class="active">v4.0.32</td>
+				<td>v1.32.0 & v2.0.0-v2.0.1</td>
+				<td>tbd</td>
+			</tr>
+			<tr>
+				<td>v4.0.31</td>
+				<td>v5.1</td>
+				<td>v4.0.26</td>
+				<td class="active">v4.0.31</td>
+				<td>v1.31.0</td>
+				<td>v1.31.0</td>
+			</tr>			
+			<tr>
+				<td>v4.0.30</td>
+				<td>v5.0</td>
+				<td>v4.0.24</td>
+				<td class="active">v4.0.30</td>
+				<td>v1.30.0</td>
+				<td>v1.30.0</td>
+			</tr>
+		</tbody>
+	</table>
 </section>
 <section>
 	<h2 id="Static_pages_.28version_.2F_run.29">Static pages (version / run)</h2>

--- a/docs/index-fr.html
+++ b/docs/index-fr.html
@@ -140,6 +140,47 @@
 	</ul>
 	<!-- <p>Les valeurs d'Intégrité des sous-ressources pour les fichiers jQuery peuvent être trouvées sur la page <a href="./sri-fr.html">d'ISR pour la SGDC</a>.</p> -->
 	<p>Si vou utilisez une version antérieure, sachez qu'elle fonctionnera quand même mais ne recevra pas de mise à jour au thème Canada.ca ou aucune correction reliée à la BOEW.</p>
+	<h3>Dépendances prises en charge</h3>
+	<table class="table table-bordered">
+		<caption class="wb-inv">Carte de version des dépendances prises en charge</caption>
+		
+		<thead>
+			<tr>
+				<th scope="col"><a href="https://github.com/wet-boew/wet-boew">WET-BOEW</a></th>
+				<th scope="col"><a href="https://github.com/wet-boew/GCWeb">GC Web</a></th>
+				<th scope="col"><a href="https://github.com/wet-boew/theme-gc-intranet">GC Intranet</a></th>
+				<th scope="col" class="active">CDTS</th>
+				<th scope="col"><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates">DotNetTemplates</a></th>
+				<th scope="col"><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/JavaTemplates">JavaTemplates</a></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><a href="https://github.com/wet-boew/wet-boew/releases/tag/v4.0.32">v4.0.32</a></td>
+				<td><a href="https://github.com/wet-boew/GCWeb/releases/tag/v6.0">v6.0</a></td>
+				<td><a href="https://github.com/wet-boew/theme-gc-intranet/releases/tag/v4.0.27">v4.0.27</a></td>
+				<td class="active">v4.0.32</td>
+				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#1.32.0">v1.32.0</a> & <a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#v2.0.0">v2.0.0</a>-<a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#v2.0.1">v2.0.1</a></td>
+				<td>tbd</td>
+			</tr>
+			<tr>
+				<td><a href="https://github.com/wet-boew/wet-boew/releases/tag/v4.0.31">v4.0.31</a></td>
+				<td><a href="https://github.com/wet-boew/GCWeb/releases/tag/v5.1">v5.1</a></td>
+				<td><a href="https://github.com/wet-boew/theme-gc-intranet/releases/tag/v4.0.26">v4.0.26</a></td>
+				<td class="active">v4.0.31</td>
+				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#1.31.0">v1.31.0</a></td>
+				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/JavaTemplates/-/releases#1.31.0">v1.31.0</a></td>
+			</tr>			
+			<tr>
+				<td><a href="https://github.com/wet-boew/wet-boew/releases/tag/v4.0.30">v4.0.30</a></td>
+				<td><a href="https://github.com/wet-boew/GCWeb/releases/tag/v5.0">v5.0</a></td>
+				<td><a href="https://github.com/wet-boew/theme-gc-intranet/releases/tag/v4.0.24">v4.0.24</a></td>
+				<td class="active">v4.0.30</td>
+				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#1.30.0">v1.30.0</a></td>
+				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/JavaTemplates/-/releases#1.30.0">v1.30.0</a></td>
+			</tr>
+		</tbody>
+	</table>
 </section>
 <section>
 	<h2 id="Pages_statiques_.28version_.2F_derni.C3.A8re_version_.C2.AB_run_.C2.BB.29">Pages statiques (version / dernière version «&#160;run&#160;»)</h2>


### PR DESCRIPTION
As the versions between WET, CDTS and other components become more segregated the need to map out the versions seems more critical.

There was consideration to create a separate map table in the DotNetTemplates but as CDTS already mentions that solution and it would be easier to maintain only one instance of this map CDTS seems to be the most logical place.