### PR TITLE
GCIntranet WET theme is not used in CDTS

### DIFF
--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -140,6 +140,7 @@
 	</ul>
 	<!-- <p>Looking for Subresource Integrity (SRI) values for jQuery files? They can be found on the <a href="./sri-en.html">SRI for CDTS page</a>.</p> -->
 	<p>Are you using an older version of the CDTS? Older versions will still work but they will not receive any updates to the Canada.ca theme or any fixes related to the WET.</p>
+	<p>GCWeb and GCIntranet use the same WET version and Canada.ca theme</p>
 	<h3>Supported Dependencies</h3>
 	<table class="table table-bordered">
 		<caption class="wb-inv">Supported Dependencies Version Map</caption>
@@ -147,7 +148,6 @@
 			<tr>
 				<th scope="col"><a href="https://github.com/wet-boew/wet-boew">WET-BOEW</a></th>
 				<th scope="col"><a href="https://github.com/wet-boew/GCWeb">GC Web</a></th>
-				<th scope="col"><a href="https://github.com/wet-boew/theme-gc-intranet">GC Intranet</a></th>
 				<th scope="col" class="active">CDTS</th>
 				<th scope="col"><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates">DotNetTemplates</a></th>
 				<th scope="col"><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/JavaTemplates">JavaTemplates</a></th>
@@ -157,7 +157,6 @@
 			<tr>
 				<td><a href="https://github.com/wet-boew/wet-boew/releases/tag/v4.0.32">v4.0.32</a></td>
 				<td><a href="https://github.com/wet-boew/GCWeb/releases/tag/v6.0">v6.0</a></td>
-				<td><a href="https://github.com/wet-boew/theme-gc-intranet/releases/tag/v4.0.27">v4.0.27</a></td>
 				<td class="active">v4.0.32</td>
 				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#1.32.0">v1.32.0</a> & <a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#v2.0.0">v2.0.0</a>-<a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#v2.1.1">v2.1.1</a></td>
 				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/JavaTemplates/-/releases#1.32.0">v1.32.0</a></td>
@@ -165,7 +164,6 @@
 			<tr>
 				<td><a href="https://github.com/wet-boew/wet-boew/releases/tag/v4.0.31">v4.0.31</a></td>
 				<td><a href="https://github.com/wet-boew/GCWeb/releases/tag/v5.1">v5.1</a></td>
-				<td><a href="https://github.com/wet-boew/theme-gc-intranet/releases/tag/v4.0.26">v4.0.26</a></td>
 				<td class="active">v4.0.31</td>
 				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#1.31.0">v1.31.0</a></td>
 				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/JavaTemplates/-/releases#1.31.0">v1.31.0</a></td>
@@ -173,7 +171,6 @@
 			<tr>
 				<td><a href="https://github.com/wet-boew/wet-boew/releases/tag/v4.0.30">v4.0.30</a></td>
 				<td><a href="https://github.com/wet-boew/GCWeb/releases/tag/v5.0">v5.0</a></td>
-				<td><a href="https://github.com/wet-boew/theme-gc-intranet/releases/tag/v4.0.24">v4.0.24</a></td>
 				<td class="active">v4.0.30</td>
 				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/DotNetTemplates/-/releases#1.30.0">v1.30.0</a></td>
 				<td><a href="https://gccode.ssc-spc.gc.ca/iitb-dgiit/sds/GOCWebTemplates/JavaTemplates/-/releases#1.30.0">v1.30.0</a></td>


### PR DESCRIPTION
@s-laugh I removed the GCIntranet column in the dependancy table because CDTS does not use the GC Intranet WET template.